### PR TITLE
read-lang-file: set 'current-directory'

### DIFF
--- a/lang-file/read-lang-file.rkt
+++ b/lang-file/read-lang-file.rkt
@@ -9,6 +9,7 @@
          )
 
 (require (only-in racket/list last)
+         (only-in racket/path path-only)
          (only-in racket/port call-with-input-string peeking-input-port)
          (only-in racket/string string-trim)
          (only-in syntax/modread with-module-reading-parameterization)
@@ -27,7 +28,8 @@
   (port-count-lines! port)
   (with-module-reading-parameterization 
    (lambda () 
-     (read-syntax (object-name port) port))))
+     (parameterize ((current-directory (or (path-only path-string) (current-directory))))
+       (read-syntax (object-name port) port)))))
 
 ;; private value eq? to itself
 (define read-language-fail (gensym 'read-language-fail))
@@ -75,9 +77,12 @@
   
   (define-runtime-path read-lang-file.rkt "read-lang-file.rkt")
   (define-runtime-path scribblings "scribblings")
+  (define-runtime-path tuvalu.rkt "test/tuvalu.rkt")
+
   (check-true (lang-file? read-lang-file.rkt))
   (check-false (lang-file? scribblings))
   (check-pred syntax? (read-lang-file read-lang-file.rkt))
+  (check-pred syntax? (read-lang-file tuvalu.rkt))
 
   (test-case "read-lang-module"
     (define (read-mod . strs)

--- a/lang-file/test/literal.rkt
+++ b/lang-file/test/literal.rkt
@@ -1,0 +1,16 @@
+#lang racket
+(require syntax/strip-context)
+
+(provide (rename-out [literal-read read]
+                     [literal-read-syntax read-syntax]))
+
+(define (literal-read in)
+  (syntax->datum
+   (literal-read-syntax #f in)))
+
+(define (literal-read-syntax src in)
+  (with-syntax ([str (port->string in)])
+    (strip-context
+     #'(module anything racket
+         (provide data)
+         (define data (quote str))))))

--- a/lang-file/test/tuvalu.rkt
+++ b/lang-file/test/tuvalu.rkt
@@ -1,0 +1,4 @@
+#lang reader "literal.rkt"
+Technology!
+System!
+Perfect!


### PR DESCRIPTION
Set 'current-directory' parameter before reading a file,
 in case the file invokes a reader module through a relative path