### PR TITLE
Add eval-lang-module

### DIFF
--- a/lang-file/lang-file/scribblings/read-lang-file.scrbl
+++ b/lang-file/lang-file/scribblings/read-lang-file.scrbl
@@ -37,3 +37,16 @@ file, false otherwise.
 Returns a string containing the the language of a @hash-lang[] file.
 }
 
+@defproc[(eval-lang-module [port input-port?]) (-> any/c any)]{
+Evaluates the contents of a @hash-lang[] file from @racket[port] and returns
+an evaluator which could be used to query @racket[provide]d identifiers.
+
+@examples[
+  (require lang-file/read-lang-file)
+  (define s (string-append "#lang racket/base\n"
+                           "(provide data)\n"
+                           "(define data 2)\n"
+                           "(println 1)\n"))
+  (define evaluator (eval-lang-module (open-input-string s)))
+  (evaluator '(list data 3))
+]}


### PR DESCRIPTION
PR for discussion. Suggestions are welcome!

`eval-lang-module` allows users to evaluate the module. The invocation will perform any side-effect that the module has. The return value is an evaluator which could be used to query `provide`d identifiers.